### PR TITLE
Supporting new versions of mongoid (>= 4.0.0)

### DIFF
--- a/lib/mongoid-embedded-errors.rb
+++ b/lib/mongoid-embedded-errors.rb
@@ -25,7 +25,8 @@ module Mongoid
             # get each of their individual message and add them to the parent's errors:
             if rel.errors.any?
               rel.errors.messages.each do |k, v|
-                key = (rel.metadata.relation == Mongoid::Relations::Embedded::Many ? "#{name}[#{i}].#{k}" : "#{name}.#{k}").to_sym
+                metadata = rel.respond_to?(:metadata) ? rel.metadata : rel.relation_metadata
+                key = (metadata.relation == Mongoid::Relations::Embedded::Many ? "#{name}[#{i}].#{k}" : "#{name}.#{k}").to_sym
                 errs.delete(key)
                 errs[key] = v
                 errs[key].flatten!

--- a/lib/mongoid-embedded-errors/version.rb
+++ b/lib/mongoid-embedded-errors/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module EmbeddedErrors
-    VERSION = "2.0.2"
+    VERSION = "2.0.2.webmedia"
   end
 end

--- a/lib/mongoid-embedded-errors/version.rb
+++ b/lib/mongoid-embedded-errors/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module EmbeddedErrors
-    VERSION = "2.0.1"
+    VERSION = "2.0.2"
   end
 end


### PR DESCRIPTION
Supporting relation metadata from any version of mongoid.

Mongoid **< 4.0.0** we have to use:
```ruby
rel.metadata
```

Mongoid **>= 4.0.0** now uses:
```ruby
rel.relation_metadata
```